### PR TITLE
Fixes motivating-example error

### DIFF
--- a/doc/source/functors.rst
+++ b/doc/source/functors.rst
@@ -33,7 +33,7 @@ This package addresses this issue through *type functors* (*i.e.* function-like 
     using NumericExtensions
 
      # benchmark
-    @time for i in 1 : 10 map(Add(), a, b) end     # -- statement(1)
+    @time for i in 1 : 10 map(NumericExtensions.Add(), a, b) end     # -- statement(1)
     @time for i in 1 : 10 a + b end                # -- statement(2)
 
 


### PR DESCRIPTION
hi,
tried your[motivating-example](http://numericextensionsjl.readthedocs.org/en/latest/functors.html#motivating-example) but got an error.

```
julia> # benchmark
       @time for i in 1 : 10 map(Add(), a, b) end     # -- statement(1)
ERROR: UndefVarError: Add not defined
 in anonymous at ./util.jl:57
```

I guess it might have changed when you split the `NumericFuns` package .. not sure..

Anyway my version:

julia> versioninfo()
Julia Version 0.4.0-dev+3966
Commit 0d3bed3* (2015-03-22 17:59 UTC)
Platform Info:
  System: Linux (x86_64-unknown-linux-gnu)
  CPU: Intel(R) Core(TM) i3-2310M CPU @ 2.10GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Sandybridge)
  LAPACK: libopenblas
  LIBM: libopenlibm
  LLVM: libLLVM-3.6.0


Probably the `readthedocs` should also be updated