### PR TITLE
0.4 tuple compat. fix #55

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.3-
 NumericFuns 0.2.1-
 ArrayViews 0.2-
+Compat

--- a/src/NumericExtensions.jl
+++ b/src/NumericExtensions.jl
@@ -2,6 +2,7 @@ module NumericExtensions
 
     using ArrayViews
     using NumericFuns
+    using Compat
 
     # size information
     import Base: size, length, ndims, isempty, stride

--- a/src/reducedim.jl
+++ b/src/reducedim.jl
@@ -163,7 +163,7 @@ macro compose_reducedim(fun, AN)
                 m = insiz[1]::Int
                 n = insiz[2]::Int
                 $(he.getstrides2)
-                sdst1, sdst2 = strides(dst)::(Int, Int)
+                sdst1, sdst2 = strides(dst)::@compat(Tuple{Int, Int})
                 $(he.getoffsets)
                 idst = offset(dst) + 1
                 $(_funimpl2d!)(op, rtup[2], rtup[1], m, n, parent(dst), idst, sdst1, sdst2, $(he.imargs2d...))
@@ -262,7 +262,7 @@ end
 # avoid the ambiguities with BitArrays
 
 _rlen(siz::Dims, d::Int) = siz[d]
-_rlen(siz::Dims, reg::(Int,Int)) = siz[reg[1]] * siz[reg[2]]
+_rlen(siz::Dims, reg::@compat(Tuple{Int,Int})) = siz[reg[1]] * siz[reg[2]]
 function _rlen(siz::Dims, reg::Dims) 
     p = 1
     for d in reg

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -41,12 +41,12 @@ function mapshape{N1,N2}(s1::NTuple{N1,Int}, s2::NTuple{N2,Int})
     end
 end
 
-mapshape(s1::(), s2::()) = ()
-mapshape(s1::Dims, s2::()) = s1
-mapshape(s1::(), s2::Dims) = s2
+mapshape(s1::@compat(Tuple{}), s2::@compat(Tuple{})) = ()
+mapshape(s1::Dims, s2::@compat(Tuple{})) = s1
+mapshape(s1::@compat(Tuple{}), s2::Dims) = s2
 
-mapshape(s1::(Int,Int), s2::(Int,)) = ((s1[1] == s2[1] && s1[2] == 1) || error("Argument dimensions are not map-compatible."); s1)
-mapshape(s1::(Int,), s2::(Int,Int)) = ((s1[1] == s2[1] && s2[2] == 1) || error("Argument dimensions are not map-compatible."); s2)
+mapshape(s1::@compat(Tuple{Int,Int}), s2::@compat(Tuple{Int})) = ((s1[1] == s2[1] && s1[2] == 1) || error("Argument dimensions are not map-compatible."); s1)
+mapshape(s1::@compat(Tuple{Int}), s2::@compat(Tuple{Int,Int})) = ((s1[1] == s2[1] && s2[2] == 1) || error("Argument dimensions are not map-compatible."); s2)
 
 mapshape(s1::Dims, s2::Dims, s3::Dims, rs::Dims...) = mapshape(mapshape(s1, s2), mapshape(s3, rs...))
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -38,7 +38,7 @@ function eachrepeat{T,I<:Integer}(x::AbstractVector{T}, rt::AbstractArray{I})
     return r
 end
 
-function eachrepeat{T}(x::AbstractMatrix{T}, rt::(Int, Int))
+function eachrepeat{T}(x::AbstractMatrix{T}, rt::@compat(Tuple{Int,Int}))
     mx = size(x, 1)
     nx = size(x, 2)
     r1::Int = rt[1]


### PR DESCRIPTION
Added Compat.jl as requirement.
Used `@compat` with new `Tuple` syntax.

fixes #55 