### PR TITLE
v0.4 compatibility and deprecation warnings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.3-
 NumericFuns 0.2.1-
 ArrayViews 0.2-
+Compat

--- a/src/NumericExtensions.jl
+++ b/src/NumericExtensions.jl
@@ -2,6 +2,7 @@ module NumericExtensions
 
     using ArrayViews
     using NumericFuns
+    using Compat
 
     # size information
     import Base: size, length, ndims, isempty, stride

--- a/src/benchmark.jl
+++ b/src/benchmark.jl
@@ -11,9 +11,9 @@ type BenchmarkTable
     rows::Vector{Vector{Float64}}
 
     function BenchmarkTable(name::ASCIIString, colnames::Vector{ASCIIString})
-        colmap = (ASCIIString=>Int)[colnames[i] => i for i in 1 : length(colnames)]
+        colmap = Dict{ASCIIString, Int}([colnames[i] => i for i in 1 : length(colnames)])
         new(name, colnames, ASCIIString[], 
-            colmap, (ASCIIString=>Int)[], Array(Vector{Float64}, 0))
+            colmap, Dict{ASCIIString, Int}(), Array(Vector{Float64}, 0))
     end
 end
 

--- a/src/folddim.jl
+++ b/src/folddim.jl
@@ -7,8 +7,8 @@
 
 import ArrayViews: parent, offset
 offset_view(a::Number, ::Int, ::Int, ::Int) = a
-offset_view(a::ContiguousArray, o::Int, m::Int) = contiguous_view(parent(a), offset(a) + o, (m,))
-offset_view(a::ContiguousArray, o::Int, m::Int, n::Int) = contiguous_view(parent(a), offset(a) + o, (m, n))
+offset_view(a::ContiguousArray, o::Int, m::Int) = ContiguousView(parent(a), offset(a) + o, (m,))
+offset_view(a::ContiguousArray, o::Int, m::Int, n::Int) = ContiguousView(parent(a), offset(a) + o, (m, n))
 
 #################################################
 #

--- a/src/map.jl
+++ b/src/map.jl
@@ -63,7 +63,7 @@ macro compose_mapfuns(fname, AN)
                 m = siz[1]::Int
                 n = siz[2]::Int
                 $(he.getstrides2)
-                sdst1, sdst2 = strides(dst)::(Int, Int)
+                sdst1, sdst2 = strides(dst)::@compat(Tuple{Int, Int})
                 $(he.getoffsets)
                 idst = offset(dst) + 1
                 if $(he.contcol) && sdst1 == 1

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -86,10 +86,10 @@ end
 reduceinit{T<:Number}(::Add, ::Type{T}) = zero(T)
 reduceinit{T<:Unsigned}(::Add, ::Type{T}) = uint(0)
 reduceinit{T<:Signed}(::Add, ::Type{T}) = 0
-reduceinit(::Add, ::Type{Int64}) = int64(0)
-reduceinit(::Add, ::Type{Uint64}) = uint64(0)
-reduceinit(::Add, ::Type{Int128}) = int128(0)
-reduceinit(::Add, ::Type{Uint128}) = uint128(0)
+reduceinit(::Add, ::Type{Int64}) = @compat(Int64(0))
+reduceinit(::Add, ::Type{Uint64}) = @compat(Uint64(0))
+reduceinit(::Add, ::Type{Int128}) = @compat(Int128(0))
+reduceinit(::Add, ::Type{Uint128}) = @compat(Uint128(0))
 reduceinit(::Add, ::Type{Bool}) = 0
 
 reduceinit{T<:Real}(::_Max, ::Type{T}) = typemin(T)

--- a/src/reducedim.jl
+++ b/src/reducedim.jl
@@ -194,7 +194,7 @@ macro compose_reducedim(fun, AN)
             insiz = $(h.inputsize)
             rsiz = Base.reduced_dims(insiz, dims)
             prod(rsiz) == length(dst) || throw(DimensionMismatch("Incorrect size of dst."))
-            $(_fun!)(contiguous_view(dst, rsiz), op, $(args...), insiz, dims)
+            $(_fun!)(ContiguousView(dst, rsiz), op, $(args...), insiz, dims)
             return dst
         end
 

--- a/src/reducedim.jl
+++ b/src/reducedim.jl
@@ -163,7 +163,7 @@ macro compose_reducedim(fun, AN)
                 m = insiz[1]::Int
                 n = insiz[2]::Int
                 $(he.getstrides2)
-                sdst1, sdst2 = strides(dst)::(Int, Int)
+                sdst1, sdst2 = strides(dst)::@compat(Tuple{Int, Int})
                 $(he.getoffsets)
                 idst = offset(dst) + 1
                 $(_funimpl2d!)(op, rtup[2], rtup[1], m, n, parent(dst), idst, sdst1, sdst2, $(he.imargs2d...))
@@ -262,7 +262,7 @@ end
 # avoid the ambiguities with BitArrays
 
 _rlen(siz::Dims, d::Int) = siz[d]
-_rlen(siz::Dims, reg::(Int,Int)) = siz[reg[1]] * siz[reg[2]]
+_rlen(siz::Dims, reg::@compat(Tuple{Int,Int})) = siz[reg[1]] * siz[reg[2]]
 function _rlen(siz::Dims, reg::Dims) 
     p = 1
     for d in reg

--- a/src/scan.jl
+++ b/src/scan.jl
@@ -6,6 +6,15 @@
 #
 #################################################
 
+# inplace scanning
+
+scan!(op::Functor{2}, r::ContiguousArray) = scan!(r, op, r)
+
+cumsum!(r::ContiguousNumericArray) = scan!(Add(), r)
+cummax!(r::ContiguousNumericArray) = scan!(MaxFun(), r)
+cummin!(r::ContiguousNumericArray) = scan!(MinFun(), r)
+
+
 macro code_scan(AN)
 
     h = codegen_helper(AN)
@@ -71,13 +80,6 @@ end
 @code_scan 2
 @code_scan 3
 
-# inplace scanning
-
-scan!(op::Functor{2}, r::ContiguousArray) = scan!(r, op, r)
-
-cumsum!(r::ContiguousNumericArray) = scan!(Add(), r)
-cummax!(r::ContiguousNumericArray) = scan!(MaxFun(), r)
-cummin!(r::ContiguousNumericArray) = scan!(MinFun(), r)
 
 
 #################################################

--- a/src/shapes.jl
+++ b/src/shapes.jl
@@ -41,12 +41,12 @@ function mapshape{N1,N2}(s1::NTuple{N1,Int}, s2::NTuple{N2,Int})
     end
 end
 
-mapshape(s1::(), s2::()) = ()
-mapshape(s1::Dims, s2::()) = s1
-mapshape(s1::(), s2::Dims) = s2
+mapshape(s1::@compat(Tuple{}), s2::@compat(Tuple{})) = ()
+mapshape(s1::Dims, s2::@compat(Tuple{})) = s1
+mapshape(s1::@compat(Tuple{}), s2::Dims) = s2
 
-mapshape(s1::(Int,Int), s2::(Int,)) = ((s1[1] == s2[1] && s1[2] == 1) || error("Argument dimensions are not map-compatible."); s1)
-mapshape(s1::(Int,), s2::(Int,Int)) = ((s1[1] == s2[1] && s2[2] == 1) || error("Argument dimensions are not map-compatible."); s2)
+mapshape(s1::@compat(Tuple{Int,Int}), s2::@compat(Tuple{Int})) = ((s1[1] == s2[1] && s1[2] == 1) || error("Argument dimensions are not map-compatible."); s1)
+mapshape(s1::@compat(Tuple{Int}), s2::@compat(Tuple{Int,Int})) = ((s1[1] == s2[1] && s2[2] == 1) || error("Argument dimensions are not map-compatible."); s2)
 
 mapshape(s1::Dims, s2::Dims, s3::Dims, rs::Dims...) = mapshape(mapshape(s1, s2), mapshape(s3, rs...))
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -38,7 +38,7 @@ function eachrepeat{T,I<:Integer}(x::AbstractVector{T}, rt::AbstractArray{I})
     return r
 end
 
-function eachrepeat{T}(x::AbstractMatrix{T}, rt::(Int, Int))
+function eachrepeat{T}(x::AbstractMatrix{T}, rt::@compat(Tuple{Int,Int}))
     mx = size(x, 1)
     nx = size(x, 2)
     r1::Int = rt[1]

--- a/src/vbroadcast.jl
+++ b/src/vbroadcast.jl
@@ -49,7 +49,7 @@ function vbroadcast!(f::Functor{2}, r::ContiguousArray, a::ContiguousArray, b::C
         if k == 1
             _vbroadcast_eachrow!(m, n, f, r, a, b)
         else
-            _vbroadcast3!(m, n, k, f, contiguous_view(r, (m,n,k)), a, b)
+            _vbroadcast3!(m, n, k, f, ContiguousView(r, (m,n,k)), a, b)
         end
     end
     return r

--- a/test/map.jl
+++ b/test/map.jl
@@ -43,8 +43,8 @@ vb4 = view(b4, 3:1:6, 2:6, 3:5, 2:5)
 
 ## test cases
 
-arrs_a = {a1, a2, a3, a4, ua1, va1, ua2, va2, ua3, va3, ua4, va4}
-arrs_b = {b1, b2, b3, b4, ub1, vb1, ub2, vb2, ub3, vb3, ub4, vb4}
+arrs_a = Any[a1, a2, a3, a4, ua1, va1, ua2, va2, ua3, va3, ua4, va4]
+arrs_b = Any[b1, b2, b3, b4, ub1, vb1, ub2, vb2, ub3, vb3, ub4, vb4]
 
 ## unary cases
 

--- a/test/norms.jl
+++ b/test/norms.jl
@@ -12,15 +12,15 @@ y2 = randn(5, 6)
 x3 = randn(3, 4, 5)
 y3 = randn(3, 4, 5)
 
-xs = {x1, x2, x3}
-ys = {y1, y2, y3}
-ps = {1, 2, 3, Inf}
+xs = Any[x1, x2, x3]
+ys = Any[y1, y2, y3]
+ps = Any[1, 2, 3, Inf]
 
-tdims = {
-    {1},   # N = 1
-    {1, 2, (1, 2)}, # N = 2
-    {1, 2, 3, (1, 2), (1, 3), (2, 3), (1, 2, 3)} # N = 3
-}
+tdims = Any[
+    Any[1],   # N = 1
+    Any[1, 2, (1, 2)], # N = 2
+    Any[1, 2, 3, (1, 2), (1, 3), (2, 3), (1, 2, 3)] # N = 3
+]
 
 safe_vnorm(x, p) = p == 1 ? sum(abs(x)) :
                    p == 2 ? sqrt(sum(abs2(x))) :

--- a/test/reduce.jl
+++ b/test/reduce.jl
@@ -84,8 +84,8 @@ x = randn(3, 4)
 
 # maximum & minimum
 
-@test_throws ErrorException maximum(Int[])
-@test_throws ErrorException minimum(Int[])
+@test_throws VERSION < v"0.4-"? ErrorException : ArgumentError maximum(Int[])
+@test_throws VERSION < v"0.4-"? ErrorException : ArgumentError minimum(Int[])
 
 @test maximum([4, 5, 2, 3]) === 5
 @test minimum([4, 5, 2, 3]) === 2
@@ -100,19 +100,19 @@ x = randn(3, 4)
 # small sample testing (for coverage)
 
 @test sumsq([2]) == 4
-@test sumsq([2:3]) == 13
-@test sumsq([2:4]) == 29
-@test sumsq([2:5]) == 54
-@test sumsq([2:6]) == 90
+@test sumsq([2,3]) == 13
+@test sumsq([2,3,4]) == 29
+@test sumsq([2,3,4,5]) == 54
+@test sumsq([2,3,4,5,6]) == 90
 
 @test meansq([2]) == 4
-@test meansq([2:3]) == 13 / 2
-@test meansq([2:4]) == 29 / 3
-@test meansq([2:5]) == 54 / 4
-@test meansq([2:6]) == 90 / 5
+@test meansq([2,3]) == 13 / 2
+@test meansq([2,3,4]) == 29 / 3
+@test meansq([2,3,4,5]) == 54 / 4
+@test meansq([2,3,4,5,6]) == 90 / 5
 
-@test maxabs([3, -5, 4, -2]) == 5
-@test minabs([3, -5, 4, -2]) == 2
+@test NumericExtensions.maxabs([3, -5, 4, -2]) == 5
+@test NumericExtensions.minabs([3, -5, 4, -2]) == 2
 
 @test dot([1, 2, 3], [4, 5, 6]) === 32
 
@@ -124,9 +124,9 @@ z = randn(3, 4)
 p = rand(3, 4)
 q = rand(3, 4)
 
-@test_approx_eq sumabs(x) sum(abs(x))
-@test_approx_eq maxabs(x) maximum(abs(x))
-@test_approx_eq minabs(x) minimum(abs(x))
+@test_approx_eq NumericExtensions.sumabs(x) sum(abs(x))
+@test_approx_eq NumericExtensions.maxabs(x) maximum(abs(x))
+@test_approx_eq NumericExtensions.minabs(x) minimum(abs(x))
 @test_approx_eq meanabs(x) mean(abs(x))
 
 @test_approx_eq sumsq(x) sum(abs2(x))
@@ -198,21 +198,21 @@ q = rand(3, 4)
 
 # folding
 
-@test_approx_eq foldl(Subtract(), 10, Abs2Fun(), [1:4]) (-20)
-@test_approx_eq foldr(Subtract(), 10, Abs2Fun(), [1:4]) 0
+@test_approx_eq foldl(Subtract(), 10, Abs2Fun(), [1,2,3,4]) (-20)
+@test_approx_eq foldr(Subtract(), 10, Abs2Fun(), [1,2,3,4]) 0
 
-@test_approx_eq foldl(Subtract(), 10, Multiply(), [1:4], [1:4]) (-20)
-@test_approx_eq foldr(Subtract(), 10, Multiply(), [1:4], [1:4]) 0
+@test_approx_eq foldl(Subtract(), 10, Multiply(), [1,2,3,4], [1,2,3,4]) (-20)
+@test_approx_eq foldr(Subtract(), 10, Multiply(), [1,2,3,4], [1,2,3,4]) 0
 
-@test_approx_eq foldl_fdiff(Subtract(), 10, Abs2Fun(), [1:4], zeros(Int,4)) (-20)
-@test_approx_eq foldr_fdiff(Subtract(), 10, Abs2Fun(), [1:4], zeros(Int,4)) 0
+@test_approx_eq foldl_fdiff(Subtract(), 10, Abs2Fun(), [1,2,3,4], zeros(Int,4)) (-20)
+@test_approx_eq foldr_fdiff(Subtract(), 10, Abs2Fun(), [1,2,3,4], zeros(Int,4)) 0
 
-@test_approx_eq foldl(Subtract(), Abs2Fun(), [1:4]) (-28)
-@test_approx_eq foldr(Subtract(), Abs2Fun(), [1:4]) (-10)
+@test_approx_eq foldl(Subtract(), Abs2Fun(), [1,2,3,4]) (-28)
+@test_approx_eq foldr(Subtract(), Abs2Fun(), [1,2,3,4]) (-10)
 
-@test_approx_eq foldl(Subtract(), Multiply(), [1:4], [1:4]) (-28)
-@test_approx_eq foldr(Subtract(), Multiply(), [1:4], [1:4]) (-10)
+@test_approx_eq foldl(Subtract(), Multiply(), [1,2,3,4], [1,2,3,4]) (-28)
+@test_approx_eq foldr(Subtract(), Multiply(), [1,2,3,4], [1,2,3,4]) (-10)
 
-@test_approx_eq foldl_fdiff(Subtract(), Abs2Fun(), [1:4], zeros(Int,4)) (-28)
-@test_approx_eq foldr_fdiff(Subtract(), Abs2Fun(), [1:4], zeros(Int,4)) (-10)
+@test_approx_eq foldl_fdiff(Subtract(), Abs2Fun(), [1,2,3,4], zeros(Int,4)) (-28)
+@test_approx_eq foldr_fdiff(Subtract(), Abs2Fun(), [1,2,3,4], zeros(Int,4)) (-10)
 

--- a/test/reducedim.jl
+++ b/test/reducedim.jl
@@ -44,18 +44,18 @@ q2 = rand(8, 7)
 q3 = rand(8, 7, 6)
 q4 = rand(8, 7, 6, 5)
 
-arrs_a = {a1, a2, a3, a4, ua1, va1, ua2, va2, ua3, va3, ua4, va4}
-arrs_b = {b1, b2, b3, b4, ub1, vb1, ub2, vb2, ub3, vb3, ub4, vb4}
-arrs_p = {p1, p2, p3, p4}
-arrs_q = {q1, q2, q3, q4}
+arrs_a = Any[a1, a2, a3, a4, ua1, va1, ua2, va2, ua3, va3, ua4, va4]
+arrs_b = Any[b1, b2, b3, b4, ub1, vb1, ub2, vb2, ub3, vb3, ub4, vb4]
+arrs_p = Any[p1, p2, p3, p4]
+arrs_q = Any[q1, q2, q3, q4]
 
-tdims = {
-    {1},   # N = 1
-    {1, 2, (1, 2)}, # N = 2
-    {1, 2, 3, (1, 2), (1, 3), (2, 3), (1, 2, 3)}, # N = 3
-    {1, 2, 3, 4, (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4), 
-     (1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4), (1, 2, 3, 4)} # N = 4
-}
+tdims = Any[
+    Any[1],   # N = 1
+    Any[1, 2, (1, 2)], # N = 2
+    Any[1, 2, 3, (1, 2), (1, 3), (2, 3), (1, 2, 3)], # N = 3
+    Any[1, 2, 3, 4, (1, 2), (1, 3), (1, 4), (2, 3), (2, 4), (3, 4), 
+     (1, 2, 3), (1, 2, 4), (1, 3, 4), (2, 3, 4), (1, 2, 3, 4)] # N = 4
+]
 
 
 # auxiliary
@@ -69,7 +69,7 @@ do_sum(a::DenseArray, reg) = sum!(zeros(Base.reduced_dims(size(a), reg)), a, reg
 do_maximum(a::DenseArray, reg) = maximum!(fill(-Inf, Base.reduced_dims(size(a), reg)), a, reg)
 do_minimum(a::DenseArray, reg) = minimum!(fill(Inf, Base.reduced_dims(size(a), reg)), a, reg)
 do_mean(a::DenseArray, reg) = mean!(rand(Base.reduced_dims(size(a), reg)), a, reg)
-do_sumabs(a::DenseArray, reg) = sumabs!(zeros(Base.reduced_dims(size(a), reg)), a, reg)
+do_sumabs(a::DenseArray, reg) = NumericExtensions.sumabs!(zeros(Base.reduced_dims(size(a), reg)), a, reg)
 
 # testing of basic functions
 
@@ -98,11 +98,11 @@ for a in arrs_a
         @test_approx_eq mean(a, reg) saferes
         @test_approx_eq do_mean(a, reg) saferes
 
-        @test_approx_eq sumabs(a, reg) sum(abs(copy(a)), reg)
+        @test_approx_eq NumericExtensions.sumabs(a, reg) sum(abs(copy(a)), reg)
         @test_approx_eq do_sumabs(a, reg) sum(abs(copy(a)), reg)
 
-        @test_approx_eq maxabs(a, reg) maximum(abs(copy(a)), reg)
-        @test_approx_eq minabs(a, reg) minimum(abs(copy(a)), reg)
+        @test_approx_eq NumericExtensions.maxabs(a, reg) maximum(abs(copy(a)), reg)
+        @test_approx_eq NumericExtensions.minabs(a, reg) minimum(abs(copy(a)), reg)
         @test_approx_eq meanabs(a, reg) mean(abs(copy(a)), reg)
         @test_approx_eq sumsq(a, reg) sum(abs2(copy(a)), reg)
         @test_approx_eq meansq(a, reg) mean(abs2(copy(a)), reg)

--- a/test/rkernels.jl
+++ b/test/rkernels.jl
@@ -52,10 +52,10 @@ for (Op, safef) in [(Add, safe_sum), (_Max, safe_max), (_Min, safe_min)]
         @test_approx_eq saccum_fdiff(Op(), n, Abs2Fun(), a, 1, v, 0) safef(abs2(a[1:n] .- v))
         @test_approx_eq saccum_fdiff(Op(), n, Abs2Fun(), v, 0, b, 1) safef(abs2(v .- b[1:n]))
 
-        @test_approx_eq saccum(Op(), n, FMA(), a, 1, b, 1, c, 1) safef(fma(a[1:n], b[1:n], c[1:n]))
-        @test_approx_eq saccum(Op(), n, FMA(), a, 3, b, 4, c, 5) safef(fma(a[3:n+2], b[4:n+3], c[5:n+4]))
-        @test_approx_eq saccum(Op(), n, FMA(), a, 1, 2, b, 1, 3, c, 1, 4) safef(fma(a[1:2:2n-1], b[1:3:3n-2], c[1:4:4n-3]))
-        @test_approx_eq saccum(Op(), n, FMA(), a, 3, 2, b, 4, 3, c, 5, 4) safef(fma(a[3:2:2n+1], b[4:3:3n+1], c[5:4:4n+1]))
+        @test_approx_eq saccum(Op(), n, FMA(), a, 1, b, 1, c, 1) safef(NumericExtensions.fma(a[1:n], b[1:n], c[1:n]))
+        @test_approx_eq saccum(Op(), n, FMA(), a, 3, b, 4, c, 5) safef(NumericExtensions.fma(a[3:n+2], b[4:n+3], c[5:n+4]))
+        @test_approx_eq saccum(Op(), n, FMA(), a, 1, 2, b, 1, 3, c, 1, 4) safef(NumericExtensions.fma(a[1:2:2n-1], b[1:3:3n-2], c[1:4:4n-3]))
+        @test_approx_eq saccum(Op(), n, FMA(), a, 3, 2, b, 4, 3, c, 5, 4) safef(NumericExtensions.fma(a[3:2:2n+1], b[4:3:3n+1], c[5:4:4n+1]))
     end
 end
 
@@ -80,7 +80,7 @@ for (Op, cf) in [(Add, +), (_Max, max), (_Min, min)]
 
         r = copy(r0[1:n])
         paccum!(Op(), n, r, 1, FMA(), a, 1, b, 1, c, 1)
-        @test_approx_eq r cf(r0[1:n], fma(a[1:n], b[1:n], c[1:n]))
+        @test_approx_eq r cf(r0[1:n], NumericExtensions.fma(a[1:n], b[1:n], c[1:n]))
 
         r = copy(r0[1:n+10])
         paccum!(Op(), n, r, 11, a, 3)
@@ -105,7 +105,7 @@ for (Op, cf) in [(Add, +), (_Max, max), (_Min, min)]
         r = copy(r0[1:n+10])
         paccum!(Op(), n, r, 11, FMA(), a, 3, b, 4, c, 5)
         @test r[1:10] == r0[1:10]
-        @test_approx_eq r[11:n+10] cf(r0[11:n+10], fma(a[3:n+2], b[4:n+3], c[5:n+4]))
+        @test_approx_eq r[11:n+10] cf(r0[11:n+10], NumericExtensions.fma(a[3:n+2], b[4:n+3], c[5:n+4]))
 
         r = copy(r0[1:4+3n])
         rc = copy(r)
@@ -145,7 +145,7 @@ for (Op, cf) in [(Add, +), (_Max, max), (_Min, min)]
         u = falses(4+3n)
         u[4:3:3n+1] = true
         @test r[~u] == rc[~u]
-        @test_approx_eq r[u] cf(rc[u], fma(a[3:2:2n+1], b[5:4:4n+1], c[6:5:5n+1]))
+        @test_approx_eq r[u] cf(rc[u], NumericExtensions.fma(a[3:2:2n+1], b[5:4:4n+1], c[6:5:5n+1]))
     end
 end
 


### PR DESCRIPTION
I understand that NumericExtensions should not be necessary for v0.4, but I am trying to maintain a package which uses it in v0.3 while also getting that package ready for v0.4, so please consider merging!

This includes changes from #56 and should fix #55, #57, and other deprecation warnings, and tests  pass (on my machine, and hopefully travis too) for both v0.3 and v0.4.